### PR TITLE
Changed mite domain name to mite.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mite-api-ts
 
-A TypeScript wrapper for the [mite](https://mite.yo.lk/) time tracking service API.
+A TypeScript wrapper for the [mite](https://mite.de/) time tracking service API.
 
 [![npm version](https://badge.fury.io/js/mite-api-ts.svg)](https://badge.fury.io/js/mite-api-ts)
 

--- a/lib/mite-client.ts
+++ b/lib/mite-client.ts
@@ -31,13 +31,13 @@ export class MiteClient {
     constructor(userAgent: string, accountName: string, apiKey: string) {
         this.accountName = accountName;
         this.apiKey = apiKey;
-        this.client = new RestClient(userAgent, 'https://corsapi.mite.yo.lk/');
+        this.client = new RestClient(userAgent, 'https://corsapi.mite.de/');
     }
 
     /**
      * Checks whether the client is authorized to make
      * requests to the mite API by sending a test request.
-     * 
+     *
      * @returns True if authorized.
      */
     public async isAuthorized(): Promise<boolean> {


### PR DESCRIPTION
I changed the used api domain to the current corsapi.mite.de. This is just for future-proofing: the legacy schema will continue to work for the foreseeable future.

Background: https://mite.de/en/blog/2023/02/14/upcoming-move-to-mite-de/